### PR TITLE
Fixed crash when holding shift and hovering on transmitter

### DIFF
--- a/api/src/main/java/com/codinglitch/simpleradio/central/Frequencing.java
+++ b/api/src/main/java/com/codinglitch/simpleradio/central/Frequencing.java
@@ -160,7 +160,7 @@ public interface Frequencing {
         if (Screen.hasShiftDown() && stack.has(REFERENCE)) {
             components.add(Component.translatable(
                     "tooltip.simpleradio.receiver_user",
-                    stack.get(REFERENCE)
+                    stack.get(REFERENCE).toString()
             ).withStyle(ChatFormatting.DARK_GRAY));
         }
     }


### PR DESCRIPTION
body text