### PR TITLE
[fix] Resolve CC computers attached to socket always being null

### DIFF
--- a/common/src/main/java/com/codinglitch/simpleradio/compat/cc/CommonCCCompat.java
+++ b/common/src/main/java/com/codinglitch/simpleradio/compat/cc/CommonCCCompat.java
@@ -16,7 +16,7 @@ public class CommonCCCompat { // thats a lot of Cs
 
     public static void putPeripheral(BlockEntity blockEntity, IPeripheral peripheral) {
         if (blockEntity instanceof Socket) {
-            SOCKET_PERIPHERALS.put(blockEntity, (SocketPeripheral<?>) peripheral);
+            SOCKET_PERIPHERALS.putIfAbsent(blockEntity, (SocketPeripheral<?>) peripheral);
         }
     }
 


### PR DESCRIPTION
`CommonCCCompat` keeps a record of every block entity that has a socket peripheral. Each time a new SocketPeripheral is constructed, this can overwrite an earlier existing block entity. Since each peripheral keeps track of their own attached computers, if it is overwritten, it loses this record and will not fire the `receive_signal` event to attached computers.

This fix makes it so socket peripherals are only stored if no entry exists for the block entity, allowing the `receive_signal` event to be fired.

Testing with 2 CC computers with the identical receiver script running:
```
while true do
    local event, data, power = os.pullEvent("receive_signal")
    local socket = peripheral.find("simpleradio:speaker")
    socket.route(data, 1)
end
```
Previously, both computers would have never received any signal event.

Demo after applying fix:

https://github.com/user-attachments/assets/b52be1cd-bec3-412d-9605-72d78f528587