### PR TITLE
[fix] Prevent peripheral feedback loop from speakers

### DIFF
--- a/common/src/main/java/com/codinglitch/simpleradio/radio/RadioSpeaker.java
+++ b/common/src/main/java/com/codinglitch/simpleradio/radio/RadioSpeaker.java
@@ -111,6 +111,11 @@ public class RadioSpeaker extends RadioRouter implements Supplier<short[]>, Spea
         return audio;
     }
 
+    @Override
+    public void accept(Source source) {
+        this.take(source);
+    }
+
     public short[] generatePacket() {
         List<short[]> totalPacketsToCombine = new ArrayList<>();
 


### PR DESCRIPTION
RadioSpeakers inherit behaviour from RadioRouter which forwards audio data to radio receivers via the socket peripheral. This causes an unavoidable (as far as im aware) infinite feedback loop if a CC computer wants to route received audio data straight to a speaker.

This change overrides the routing behaviour for speakers to effectively sink this data rather than pass it on to an audio receiver.