### PR TITLE
fix: jukeboxes not working on the radio

### DIFF
--- a/common/src/main/java/com/codinglitch/simpleradio/CompatCore.java
+++ b/common/src/main/java/com/codinglitch/simpleradio/CompatCore.java
@@ -110,7 +110,7 @@ public class CompatCore {
 
     public static String getSound(HolderLookup.Provider provider, ItemStack stack) {
         String result = Services.COMPAT.getSound(stack);
-        if (result != null) return result;
+        if (result != null && !result.isBlank()) return result;
 
         Optional<Holder<JukeboxSong>> song = JukeboxSong.fromStack(provider, stack);
         return song.map(s -> s.value().soundEvent().value().getLocation().toString()).orElse(null);


### PR DESCRIPTION
The bug was that `CompatCore.getSound(...)` treated any non-null value from platform/compatibility hooks as a valid sound identifier, so an empty string returned by a compat implementation (e.g. NeoForge) prevented falling back to the vanilla `JukeboxSong.fromStack(...)`. Because `MixinJukeboxSongPlayer` calls `RadioManager.sendRecord` / `updateRecord` with the jukebox `ItemStack`, that empty/invalid sound identifier got propagated into the radio pipeline and clients could not resolve or play the music disc. I fixed it by requiring the compat hook result to be non-null and non-blank (`!result.isBlank()`). This allows the code to fall back to the jukebox song data when the compat layer provides no valid sound.